### PR TITLE
docs(pictures): update README file with endpoints and test info

### DIFF
--- a/services/pictures-flask/README.md
+++ b/services/pictures-flask/README.md
@@ -9,7 +9,33 @@ Local Dev
 pip install -r requirements.txt
 pytest -q
 FLASK_APP=app/main.py flask run -p 8001
-# http://localhost:8001/health ```
+# http://localhost:8001/health 
+```
+
+---
+
+## RESTful API Endpoints (planned schema)
+
+| Action | Method | Return code | Body                        | URL Endpoint     |
+|--------|--------|-------------|-----------------------------|------------------|
+| List   | GET    | 200 OK      | Array of picture URLs `[{...}]` | `GET /picture`     |
+| Create | POST   | 201 CREATED | A picture resource as JSON `{...}` | `POST /picture`    |
+| Read   | GET    | 200 OK      | A picture as JSON `{...}`   | `GET /picture/{id}` |
+| Update | PUT    | 200 OK      | A picture as JSON `{...}`   | `PUT /picture/{id}` |
+| Delete | DELETE | 204 NO CONTENT | `""`                      | `DELETE /picture/{id}` |
+
+---
+
+
+## Existing Endpoints (already implemented)
+
+| Action | Method | Return code | Body | URL Endpoint |
+|--------|--------|-------------|------|--------------|
+| Health | GET    | 200 OK      | `""` | `GET /health` |
+| Count  | GET    | 200 OK      | `""` | `GET /count`  |
+
+---
+
 
 ## Configuration (env)
 
@@ -18,4 +44,17 @@ FLASK_APP=app/main.py flask run -p 8001
 - `ENV` — dev/prod
   
 ## Tests
-- `pytest` under `tests/` covers health and basic endpoint behavior.
+
+The previous developer wrote tests for the service. At the moment:
+- Only `/health` and `/count` tests pass.
+- Other tests fail until the CRUD endpoints are implemented.
+
+Run only passing tests:
+```bash
+pytest -k 'test_health or test_count'
+```
+
+Run all tests (expected failures for unimplemented endpoints):
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
Update the README for the **Pictures** service to document RESTful API endpoints (planned and existing) and testing instructions.

## Changes
- Added a Markdown table with all planned endpoints (`/picture`, `/picture/{id}`) from the provided architecture schema.
- Documented the existing endpoints (`/health`, `/count`) that were implemented by the previous developer (by scenario).
- Added notes about running pytest:
  - Only `test_health` and `test_count` currently pass.
  - How to run subset of tests with the `-k` flag.

## Testing
- Verified the README renders correctly in GitHub UI.
- Ran `pytest -k 'test_health or test_count'` → confirmed 2 passing tests.
- A full `pytest` run fails as expected until endpoints are implemented.

## Risks & Impact
- Risk: Low — documentation-only changes.
- Impact: clarifies project state for developers and reviewers.

## Next Steps
- Implement the GET /picture endpoint
- Keep README updated as implementation progresses.
