### PR TITLE
Feat/pictures read api

### DIFF
--- a/services/pictures-flask/backend/routes.py
+++ b/services/pictures-flask/backend/routes.py
@@ -35,7 +35,9 @@ def count():
 ######################################################################
 @app.route("/picture", methods=["GET"])
 def get_pictures():
-    pass
+    """return all pictures in data"""
+    if data:
+        return jsonify(data), 200
 
 ######################################################################
 # GET A PICTURE

--- a/services/pictures-flask/backend/routes.py
+++ b/services/pictures-flask/backend/routes.py
@@ -46,7 +46,11 @@ def get_pictures():
 
 @app.route("/picture/<int:id>", methods=["GET"])
 def get_picture_by_id(id):
-    pass
+    for picture in data:
+        if picture["id"] == id:
+            # print(picture["pic_url"])
+            return jsonify(picture), 200
+    return jsonify({"Message": f"picture with id {id} not found"}), 404
 
 
 ######################################################################


### PR DESCRIPTION
## Summary
Add the **READ endpoints** for the Pictures service:  
- `GET /picture` (list all pictures)  
- `GET /picture/<id>` (fetch single picture by ID)

These endpoints complete the "read" side of the Pictures API and allow basic retrieval of picture data from the JSON store.

---

## Changes
- Implemented `GET /picture` in `backend/routes.py`:
  - Returns all picture objects from `data`
  - Returns `200 OK` with JSON array
- Implemented `GET /picture/<id>` in `backend/routes.py`:
  - Returns matching picture object if found
  - Returns `404 Not Found` with JSON message if ID does not exist

---

## Testing
- Verified with `pipenv run pytest -q`:
  - ✅ `test_health`  
  - ✅ `test_count`  
  - ✅ `test_data_contains_10_pictures`  
  - ✅ `test_get_picture`  
  - ✅ `test_get_pictures_check_content_type_equals_json`  
  - ✅ `test_get_picture_by_id`  
  - ✅ `test_pictures_json_is_not_empty`  
- All 7 READ-related tests passing.

---

## Risks & Impact
- Risk: **Low** — only adds new endpoints, does not modify existing ones.
- Impact scope: Pictures service only.

---

## Next Steps
- Implement WRITE endpoints:
  - `POST /picture`
  - `PUT /picture/<id>`
  - `DELETE /picture/<id>`
- Expand README with example `curl` commands for the new endpoints.
