### PR TITLE
feat(pictures): add write endpoints (POST/PUT/DELETE)

### DIFF
--- a/services/pictures-flask/backend/routes.py
+++ b/services/pictures-flask/backend/routes.py
@@ -85,4 +85,8 @@ def update_picture(id):
 ######################################################################
 @app.route("/picture/<int:id>", methods=["DELETE"])
 def delete_picture(id):
-    pass
+    for index, picture in enumerate(data):
+        if picture["id"] == id:
+            data.pop(index)
+            return "", 204
+    return jsonify({"Message": "picture not"}), 404

--- a/services/pictures-flask/backend/routes.py
+++ b/services/pictures-flask/backend/routes.py
@@ -72,7 +72,13 @@ def create_picture():
 
 @app.route("/picture/<int:id>", methods=["PUT"])
 def update_picture(id):
-    pass
+    uploaded_picture = request.get_json()
+    for index, picture in enumerate(data):
+        if picture["id"] == id:
+            data[index] = uploaded_picture
+            return jsonify(picture), 200
+
+    return jsonify({"Message": f"picture not"}), 404
 
 ######################################################################
 # DELETE A PICTURE

--- a/services/pictures-flask/backend/routes.py
+++ b/services/pictures-flask/backend/routes.py
@@ -58,7 +58,12 @@ def get_picture_by_id(id):
 ######################################################################
 @app.route("/picture", methods=["POST"])
 def create_picture():
-    pass
+    uploaded_picture = request.get_json()
+    for picture in data:
+        if picture["id"] == uploaded_picture["id"]:
+            return jsonify({"Message": f"picture with id {picture['id']} already present"}), 302
+    data.append(uploaded_picture)
+    return jsonify(uploaded_picture), 201
 
 ######################################################################
 # UPDATE A PICTURE


### PR DESCRIPTION
## Summary
Add the **WRITE endpoints** for the Pictures service:  
- `POST /picture` (create with duplicate check)  
- `PUT /picture/<id>` (update existing by ID with 404 handling)  
- `DELETE /picture/<id>` (delete by ID with 204/404 responses)

---

## Changes
- Implemented `POST /picture`:
  - Accepts JSON body with picture data.
  - Returns 302 if ID already exists, 201 otherwise.
- Implemented `PUT /picture/<id>`:
  - Updates picture record if found, returns 200.
  - Returns 404 if picture not found.
- Implemented `DELETE /picture/<id>`:
  - Removes picture from list if found, returns 204.
  - Returns 404 if picture not found.

---

## Testing
- Verified with `pipenv run pytest -q`:
  - ✅ `test_post_picture`
  - ✅ `test_post_picture_duplicate`
  - ✅ `test_update_picture_by_id`
  - ✅ `test_delete_picture_by_id`
- All WRITE-related tests passing.

---

## Risks & Impact
- Risk: Low — affects Pictures service only.
- Data stored in-memory; persistence will be needed in future.

---

## Next Steps
- Update Pictures service README with new state
- Move to the next service Songs