### PR TITLE
chore(infra): add local MongoDB setup with docker-compose and init user to Songs svc

### DIFF
--- a/services/songs-flask/.env.example
+++ b/services/songs-flask/.env.example
@@ -1,0 +1,21 @@
+# Copy to .env and adjust as needed
+MONGO_INITDB_ROOT_USERNAME=admin
+MONGO_INITDB_ROOT_PASSWORD=adminpass
+MONGO_INITDB_DATABASE=app_db
+
+# host port to expose Mongo (change if 27017 is busy)
+MONGODB_PORT=27017
+
+# application user (created via init script)
+MONGO_APP_USERNAME=app_user
+MONGO_APP_PASSWORD=app_pass
+
+# mongo express login details
+ME_UI_USER=meadmin
+ME_UI_PASS=meadminpass
+
+# Flask uses this during development
+FLASK_ENV=development
+
+# points to local dockerized MongoDB
+MONGO_URI=mongodb://app_user:app_pass@localhost:27017/app_db?authSource=app_db

--- a/services/songs-flask/docker-compose.yml
+++ b/services/songs-flask/docker-compose.yml
@@ -1,0 +1,42 @@
+version: "3.9"
+services:
+  mongodb:
+    image: mongo:7
+    container_name: local-mongodb
+    restart: unless-stopped
+    ports:
+      - "${MONGODB_PORT}:27017"
+    env_file: .env
+    environment:
+      # used by the official image to bootstrap admin user
+      - MONGO_INITDB_ROOT_USERNAME=${MONGO_INITDB_ROOT_USERNAME}
+      - MONGO_INITDB_ROOT_PASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
+      - MONGO_INITDB_DATABASE=${MONGO_INITDB_DATABASE}
+    volumes:
+      - mongo_data:/data/db
+      - ./infra/mongo/init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD", "mongosh", "mongodb://localhost:27017", "--eval", "db.adminCommand('ping')"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # optional: web UI to inspect db (visit http://localhost:8081)
+  mongo-express:
+    image: mongo-express:1
+    container_name: local-mongo-express
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    env_file: .env
+    environment:
+      - ME_CONFIG_MONGODB_SERVER=mongodb
+      - ME_CONFIG_MONGODB_PORT=27017
+      - ME_CONFIG_MONGODB_ADMINUSERNAME=${MONGO_INITDB_ROOT_USERNAME}
+      - ME_CONFIG_MONGODB_ADMINPASSWORD=${MONGO_INITDB_ROOT_PASSWORD}
+    depends_on:
+      mongodb:
+        condition: service_healthy
+
+volumes:
+  mongo_data:

--- a/services/songs-flask/infra/mongo/init/01-init.js
+++ b/services/songs-flask/infra/mongo/init/01-init.js
@@ -1,0 +1,10 @@
+// runs automatically on first container start
+db = db.getSiblingDB(process.env.MONGO_INITDB_DATABASE || "app_db");
+
+db.createUser({
+  user: process.env.MONGO_APP_USERNAME || "app_user",
+  pwd:  process.env.MONGO_APP_PASSWORD || "app_pass",
+  roles: [
+    { role: "readWrite", db: db.getName() }
+  ]
+});


### PR DESCRIPTION
## Summary
Introduce a local MongoDB environment for the Songs service using Docker Compose.
Includes authentication, persistent volume, healthcheck, and optional Mongo Express UI.

---

## Changes
- Added `.env` and `.env.example` in root for MongoDB config.
- Added `songs-flask/docker-compose.yml` with MongoDB and Mongo Express services.
- Added `songs-flask/infra/mongo/init/01-init.js` init script to create app user.
- Added `services/songs-flask/.env.example` with `MONGO_URI` for Flask integration.
- Documented connection strings and usage in developer notes.

---

## Testing
- Ran `docker compose up -d mongodb` and verified container health:
  ```bash
  docker compose ps
  docker logs -f local-mongodb
  ```
- Connected with:
  ```bash
  docker exec -it local-mongodb mongosh "mongodb://<root>:<pass>@localhost:27017/admin"
  ```
- Verified successful db.runCommand({ ping: 1 }).
- Optional: confirmed mongo-express UI is accessible at http://localhost:8081/

## Risks & Impact
- Risk: Low — dev-only infrastructure.
- Impact scope: local development only, no application code changes.

## Next Steps
- Create a follow-up PR to integrate Flask Songs service with MongoDB (MONGO_URI).
- Add PyMongo adapter in services/songs-flask.