### PR TITLE
feat(songs): add /health and /count endpoints with local MongoDB setup

### DIFF
--- a/services/songs-flask/.env.example
+++ b/services/songs-flask/.env.example
@@ -1,21 +1,38 @@
-# Copy to .env and adjust as needed
+# services/songs-flask/.env.example
+# Copy this file to `.env` and adjust values as needed. Do NOT commit `.env`.
+
+# -----------------------------------------------------------------------------
+# MongoDB bootstrap (used by Docker container on first start)
+# -----------------------------------------------------------------------------
 MONGO_INITDB_ROOT_USERNAME=admin
 MONGO_INITDB_ROOT_PASSWORD=adminpass
 MONGO_INITDB_DATABASE=app_db
 
-# host port to expose Mongo (change if 27017 is busy)
+# Host port to expose MongoDB (change if 27017 is busy)
 MONGODB_PORT=27017
 
-# application user (created via init script)
+# Application user (created by init script /infra/mongo/init/01-init.js)
 MONGO_APP_USERNAME=app_user
 MONGO_APP_PASSWORD=app_pass
 
-# mongo express login details
+# Optional admin UI (mongo-express) basic auth
 ME_UI_USER=meadmin
 ME_UI_PASS=meadminpass
 
-# Flask uses this during development
+# -----------------------------------------------------------------------------
+# Flask development settings
+# -----------------------------------------------------------------------------
 FLASK_ENV=development
+PORT_SONGS=8002
 
-# points to local dockerized MongoDB
-MONGO_URI=mongodb://app_user:app_pass@localhost:27017/app_db?authSource=app_db
+# -----------------------------------------------------------------------------
+# Mongo connection components for building MONGO_URI
+# -----------------------------------------------------------------------------
+MONGODB_HOST=localhost
+MONGO_DB=app_db
+# For app user, authSource should be the application DB (app_db).
+# If you use root, set MONGO_AUTH_SOURCE=admin instead.
+MONGO_AUTH_SOURCE=${MONGO_DB}
+
+# Final connection string used by Flask; built from the components above.
+MONGO_URI=mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}/${MONGO_DB}?authSource=${MONGO_AUTH_SOURCE}

--- a/services/songs-flask/Pipfile
+++ b/services/songs-flask/Pipfile
@@ -4,13 +4,10 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-werkzeug = "==2.1.2"
 sqlalchemy = "==1.4.46"
 pymongo = "*"
-flask = "*"
 flask-sqlalchemy = "==2.5.1"
 psycopg2-binary = "==2.9.3"
-python-dotenv = "==0.20.0"
 flask-talisman = "*"
 flask-cors = "*"
 gunicorn = "==20.1.0"
@@ -24,6 +21,9 @@ factory-boy = "==2.12.0"
 pytest = "*"
 coverage = "==6.3.2"
 httpie = "==3.2.1"
+python-dotenv = "*"
+flask = "==2.3.3"
+werkzeug = "==2.3.8"
 
 [dev-packages]
 

--- a/services/songs-flask/Pipfile.lock
+++ b/services/songs-flask/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7ed0f99ca3c85f646a77a36cfa2446d109e4dddf4b336ac1f855f6fb7f249d96"
+            "sha256": "e6a53fcd82a9172369e277d0d94c0487a58aeae7c7d4d8c929cd85a6246b38a0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -54,6 +54,14 @@
             "index": "pypi",
             "markers": "python_full_version >= '3.6.2'",
             "version": "==22.3.0"
+        },
+        "blinker": {
+            "hashes": [
+                "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf",
+                "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"
+            ],
+            "markers": "python_version >= '3.9'",
+            "version": "==1.9.0"
         },
         "certifi": {
             "hashes": [
@@ -272,12 +280,12 @@
         },
         "flask": {
             "hashes": [
-                "sha256:15972e5017df0575c3d6c090ba168b6db90259e620ac8d7ea813a396bad5b6cb",
-                "sha256:9013281a7402ad527f8fd56375164f3aa021ecfaff89bfe3825346c24f87e04c"
+                "sha256:09c347a92aa7ff4a8e7f3206795f30d826654baf38b873d0744cd571ca609efc",
+                "sha256:f69fcd559dc907ed196ab9df0e48471709175e696d6e698dd4dbe940f96ce66b"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.3"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.3.3"
         },
         "flask-cors": {
             "hashes": [
@@ -977,12 +985,12 @@
         },
         "python-dotenv": {
             "hashes": [
-                "sha256:b7e3b04a59693c42c36f9ab1cc2acc46fa5df8c78e178fc33a8d4cd05c8d498f",
-                "sha256:d92a187be61fe482e4fd675b6d52200e7be63a12b724abbf931a40ce4fa92938"
+                "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc",
+                "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.5'",
-            "version": "==0.20.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.1.1"
         },
         "requests": {
             "extras": [
@@ -1139,12 +1147,12 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1ce08e8093ed67d638d63879fd1ba3735817f7a80de3674d293f5984f25fb6e6",
-                "sha256:72a4b735692dd3135217911cbeaa1be5fa3f62bffb8745c5215420a03dc55255"
+                "sha256:554b257c74bbeb7a0d254160a4f8ffe185243f52a52035060b761ca62d977f03",
+                "sha256:bba1f19f8ec89d4d607a3bd62f1904bd2e609472d93cd85e9d4e178f472c3748"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==2.1.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.3.8"
         },
         "wrapt": {
             "hashes": [


### PR DESCRIPTION
## Summary
Introduce initial functional setup for the Songs microservice, including environment, dependencies, MongoDB integration, and the first endpoints.

## Changes
- Added Pipenv dependency management for Songs service.
- Installed and configured `python-dotenv` to load `.env` variables.
- Updated Flask version for compatibility with modern CLI (`--app` flag).
- Added local MongoDB container setup (via docker-compose, with `.env` and `.env.example` templates).
- Connected Flask app to local MongoDB container using `MONGO_URI` from `.env`.
- Implemented two base endpoints:
  - `GET /health` → returns app status.
  - `GET /count` → counts documents in `songs` collection.

## Testing
- Verified `.env` loads correctly via `python-dotenv`.
- Ran MongoDB in Docker:
  ```bash
  docker compose up -d mongodb
  ```
- Started Flask server with:
  ```bash
  pipenv run flask --app backend/routes.py run -p 8002
  ```
- Checked endpoints:
  ```bash
  curl.exe -s http://localhost:8002/health   # {"status": "OK"}
  curl.exe -s http://localhost:8002/count    # {"count": <num>}
  ```
- Confirmed all basic tests pass.

## Risks & Impact
- Risk: Low. Affects only Songs service local dev setup.
- Uses Docker volume for persistence; dropping/re-creating volumes resets DB.

## Next Steps
- Implement CRUD endpoints for song resource (GET /song, POST /song, PUT /song/{id}, DELETE /song/{id}).
- Update Songs README with examples of calling new endpoints.
   