### PR TITLE
feat(songs): add write endpoints (POST/PUT/DELETE)

### DIFF
--- a/services/songs-flask/backend/routes.py
+++ b/services/songs-flask/backend/routes.py
@@ -135,7 +135,26 @@ def create_song():
     
     result = db.songs.insert_one(song)
     return parse_json(song), 201
+
+@app.route("/song/<int:id>", methods=["PUT"])
+def update_song(id):
+    uploaded_song = request.json
+
+    target_song = db.songs.find_one({"id":id})
+    if not target_song:
+        return jsonify({"Message": f"song not found"}), 404 
+
+    result = db.songs.update_one(
+        {"id": id},
+        {"$set": {"lyrics": uploaded_song["lyrics"], "title": uploaded_song["title"]}}
+    )
     
-# def create_song(): ...
-# def update_song(id): ...
+    if result.modified_count == 0:
+        return {"message": "song found, but nothing updated"}, 200
+    else:
+        return parse_json(db.songs.find_one({"id": id})), 201
+
+    updated_song = db.songs.find_one({"id": id})
+    return parse_json(updated_song), 200
+
 # def delete_song(id): ...

--- a/services/songs-flask/backend/routes.py
+++ b/services/songs-flask/backend/routes.py
@@ -125,7 +125,17 @@ def get_song_by_id(id):
     return jsonify({"Message": f"song with id {id} not found"}), 404
 
 
-# def get_song_by_id(id): ...
+@app.route("/song", methods=["POST"])
+def create_song():
+    song = request.json
+    print(type(song))
+    # check if such song with ID already exists
+    if db.songs.find_one({"id":song["id"]}):
+        return jsonify({"Message": f"song with id {song['id']} already present"}), 302
+    
+    result = db.songs.insert_one(song)
+    return parse_json(song), 201
+    
 # def create_song(): ...
 # def update_song(id): ...
 # def delete_song(id): ...

--- a/services/songs-flask/backend/routes.py
+++ b/services/songs-flask/backend/routes.py
@@ -157,4 +157,12 @@ def update_song(id):
     updated_song = db.songs.find_one({"id": id})
     return parse_json(updated_song), 200
 
-# def delete_song(id): ...
+@app.route("/song/<int:id>", methods=["DELETE"])
+def delete_song(id):
+
+    result = db.songs.delete_one({"id": id})
+
+    if result.deleted_count == 0:
+        return {"message": "song not found"}, 404
+    else:
+        return "", 204


### PR DESCRIPTION
## Summary
Introduce full write support for the Songs service by adding `POST`, `PUT`, and `DELETE` endpoints backed by MongoDB.

## Changes
- Added `POST /song`:
  - Inserts a new song document into MongoDB.
  - Returns `302` if a song with the same ID already exists.
- Added `PUT /song/<id>`:
  - Updates an existing song’s lyrics and title.
  - Returns `404` if not found.
  - Returns `200` with message if nothing changed, or `201` with updated document if modified.
- Added `DELETE /song/<id>`:
  - Deletes a song by ID.
  - Returns `204` if deleted, `404` if not found.

## Testing
- Verified endpoints manually with `curl` and PowerShell:
  - `POST /song` — creates new or returns duplicate warning.
  - `PUT /song/<id>` — updates song or shows not found.
  - `DELETE /song/<id>` — deletes song or shows not found.
- Confirmed correct HTTP codes: `201`, `302`, `200`, `404`, `204`.

## Risks & Impact
- Risk: Low. Changes are additive, affecting only Songs service endpoints.
- MongoDB data persists in Docker volume; repeated tests may require resetting volume.

## Next Steps
- Extend API docs in Songs README.
