### PR TITLE
docs(songs): complete README with local Mongo and CRUD examples

### DIFF
--- a/services/songs-flask/README.md
+++ b/services/songs-flask/README.md
@@ -1,20 +1,28 @@
 # Songs Service (Flask + MongoDB)
 
-Flask microservice for songs and lyrics, backed by MongoDB.
+Flask microservice for songs and lyrics, backed by MongoDB.  
+Implements full CRUD on the `songs` collection and system endpoints for health and document count.
 
 ---
 
 ## RESTful API Endpoints (planned schema)
 
-| Action | Method  | Return code   | Body                          | URL Endpoint     |
-|--------|---------|---------------|-------------------------------|------------------|
-| Health | GET     | 200 OK        | `""`                          | `GET /health`    |
-| Count  | GET     | 200 OK        | `""`                          | `GET /count`     |
-| List   | GET     | 200 OK        | Array of songs `[{...}]`      | `GET /song`      |
-| Create | POST    | 201 CREATED   | A song resource as JSON `{...}` | `POST /song`    |
-| Read   | GET     | 200 OK / 404  | A song as JSON `{...}`        | `GET /song/{id}` |
-| Update | PUT     | 200 OK / 404  | A song as JSON `{...}`        | `PUT /song/{id}` |
-| Delete | DELETE  | 204 / 404     | `""`                          | `DELETE /song/{id}` |
+| Action | Method  | Return code        | Body                            | URL Endpoint        |
+|-------:|---------|--------------------|---------------------------------|---------------------|
+| Health | GET     | 200 OK             | `{"status":"OK"}`               | `GET /health`       |
+| Count  | GET     | 200 OK             | `{"count": <int>}`              | `GET /count`        |
+| List   | GET     | 200 OK             | Array of songs `[{...}]`        | `GET /song`         |
+| Read   | GET     | 200 OK / 404       | A song as JSON `{...}`          | `GET /song/{id}`    |
+| Create | POST    | 201 CREATED / 302  | Created song as JSON `{...}`    | `POST /song`        |
+| Update | PUT     | 201 / 200 / 404    | Updated song as JSON `{...}`    | `PUT /song/{id}`    |
+| Delete | DELETE  | 204 NO CONTENT/404 | `""`                            | `DELETE /song/{id}` |
+
+**Notes**
+- `302` on `POST` means a song with the given `id` already exists.
+- `PUT` returns:
+  - `201` if modified and returns the updated document;
+  - `200` with `{"message":"song found, but nothing updated"}` if no changes;
+  - `404` if target song not found.
 
 ---
 
@@ -27,6 +35,12 @@ docker compose up -d mongodb
 # optional UI
 docker compose up -d mongo-express
 ```
+Check:
+
+```bash
+docker compose ps
+docker logs -f local-mongodb
+```
 
 - MongoDB will be available at `localhost:27017`.  
 - Optional admin UI (Mongo Express) available at [http://localhost:8081](http://localhost:8081).  
@@ -34,6 +48,8 @@ docker compose up -d mongo-express
 Stop containers:
 ```bash
 docker compose down
+# or wipe data to re-bootstrap init scripts:
+docker compose down -v
 ```
 
 ---
@@ -42,8 +58,10 @@ docker compose down
 ```bash
 cd services/songs-flask
 pipenv install -r requirements.txt
-pipenv shell
-flask --app backend/routes.py run -p 8002
+# (optional) pin modern CLI support
+pipenv install "Flask==2.3.3" "Werkzeug==2.3.8"
+# run
+pipenv run flask --app backend/routes.py run -p 8002 --reload
 # http://localhost:8002/health
 ```
 
@@ -56,7 +74,8 @@ pytest -q
 
 ## Configuration (env)
 
-Environment variables are stored in `.env` (not committed) and `.env.example` (committed).
+Environment variables are stored in .env (not committed) and .env.example (committed).
+python-dotenv used to load .env into the Flask process only (not system-wide).
 
 ### MongoDB (from `.env`)
 - `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD` — root credentials for container bootstrap.  
@@ -70,18 +89,72 @@ Environment variables are stored in `.env` (not committed) and `.env.example` (c
 - `MONGO_URI=mongodb://app_user:app_pass@localhost:27017/app_db?authSource=app_db`  
 - `PORT_SONGS=8002`  
 
+### Build blocks for MONGO_URI
+- MONGODB_HOST=localhost
+- MONGO_DB=app_db
+- MONGO_AUTH_SOURCE=${MONGO_DB}   # use "admin" if connecting as root
+
+### Final connection string used by Flask (override or keep generated)
+- MONGO_URI=mongodb://${MONGO_APP_USERNAME}:${MONGO_APP_PASSWORD}@${MONGODB_HOST}:${MONGODB_PORT}/${MONGO_DB}?authSource=${MONGO_AUTH_SOURCE}
+
 ---
 
 ## Init Script
 
 On first container start, the official `mongo:7` image executes all `.js` files from `/docker-entrypoint-initdb.d`.
 
-We use:  
+Used:  
 `infra/mongo/init/01-init.js` — creates the application user with `readWrite` role for `app_db`.
 
 ---
 
+## Example Requests
+
+### Health & Count
+
+```bash
+curl.exe -s http://localhost:8002/health
+# {"status":"OK"}
+
+curl.exe -s http://localhost:8002/count
+# {"count": 20}
+```
+
+### List & Read
+
+```bash
+curl.exe -s http://localhost:8002/song
+curl.exe -s http://localhost:8002/song/1
+```
+
+### Create
+
+```bash
+curl.exe -s -X POST http://localhost:8002/song \
+  -H "Content-Type: application/json" \
+  -d '{"id":323,"title":"in faucibus orci luctus et ultrices","lyrics":"..."}'
+# 201 on success; 302 if duplicate id
+```
+
+### Update
+
+```bash
+curl.exe -s -X PUT http://localhost:8002/song/1 \
+  -H "Content-Type: application/json" \
+  -d '{"title":"yay song","lyrics":"yay hey yay yay"}'
+# 201 updated doc / 200 no changes / 404 not found
+```
+
+### Delete
+
+```bash
+curl.exe -s -X DELETE http://localhost:8002/song/14
+# 204 on success / 404 if not found
+```
+
 ## Current Status
-- MongoDB container working locally.  
-- Flask service configured with Pipenv.  
-- API endpoints are placeholders — to be implemented in upcoming steps.  
+
+- ✅ MongoDB container works locally; app user is provisioned via init script.
+- ✅ Flask service configured via Pipenv and python-dotenv.
+- ✅ Implemented endpoints: /health, /count, GET /song, GET /song/<id>, POST /song, PUT /song/<id>, DELETE /song/<id>.
+- ✅ README documents how to run, configure, and call the API.


### PR DESCRIPTION
## Summary
Update Songs service README to reflect the current state of the microservice, including MongoDB setup, environment configuration, and full CRUD API.

## Changes
- Documented Docker-based MongoDB setup and optional mongo-express UI.
- Clarified `.env` configuration and `MONGO_URI` resolution with variable expansion.
- Added endpoint table for `/health`, `/count`, and CRUD on `/song`.
- Included copy-paste examples for each endpoint.
- Added troubleshooting tips and current status.

## Testing
- Verified all examples against a running local stack:
  - `docker compose up -d mongodb`
  - `pipenv run flask --app backend/routes.py run -p 8002 --reload`
  - `curl` requests to endpoints return expected codes and payloads.

## Risks & Impact
- Risk: Low. Documentation-only changes.
- Impact: Improves consistency across services.

## Next Steps
- Move to main Django app implementation